### PR TITLE
feat: add spec-driven development functionality

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -41,6 +41,10 @@ pub enum Commands {
         /// Force initialization even if already initialized
         #[arg(short, long)]
         force: bool,
+
+        /// Generate CLAUDE.md for AI assistance
+        #[arg(long = "claude-md", alias = "claude")]
+        claude_md: bool,
     },
 
     /// Create a new ticket
@@ -279,6 +283,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: ConfigCommands,
     },
+
+    /// Manage specifications (spec-driven development)
+    Spec {
+        #[command(subcommand)]
+        command: SpecCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -309,6 +319,21 @@ pub enum ConfigCommands {
         /// Confirm reset
         #[arg(long)]
         force: bool,
+    },
+
+    /// Generate or update CLAUDE.md for AI assistance
+    Claude {
+        /// Append to existing CLAUDE.md instead of overwriting
+        #[arg(short, long)]
+        append: bool,
+
+        /// Template to use (basic, advanced)
+        #[arg(short, long, default_value = "basic")]
+        template: String,
+
+        /// Output path for CLAUDE.md (defaults to project root)
+        #[arg(short, long)]
+        output: Option<String>,
     },
 }
 
@@ -371,5 +396,144 @@ pub enum TaskCommands {
         /// Force removal without confirmation
         #[arg(short, long)]
         force: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SpecCommands {
+    /// Initialize a new specification
+    Init {
+        /// Specification title
+        title: String,
+
+        /// Specification description
+        #[arg(short, long)]
+        description: Option<String>,
+
+        /// Associated ticket ID
+        #[arg(short, long)]
+        ticket: Option<String>,
+
+        /// Initial tags (comma-separated)
+        #[arg(long)]
+        tags: Option<String>,
+    },
+
+    /// Create or update requirements document
+    Requirements {
+        /// Specification ID (defaults to active spec)
+        #[arg(short, long)]
+        spec: Option<String>,
+
+        /// Open in editor
+        #[arg(short, long)]
+        editor: bool,
+
+        /// Mark as complete
+        #[arg(long)]
+        complete: bool,
+    },
+
+    /// Create or update design document
+    Design {
+        /// Specification ID (defaults to active spec)
+        #[arg(short, long)]
+        spec: Option<String>,
+
+        /// Open in editor
+        #[arg(short, long)]
+        editor: bool,
+
+        /// Mark as complete
+        #[arg(long)]
+        complete: bool,
+    },
+
+    /// Create or update implementation tasks
+    Tasks {
+        /// Specification ID (defaults to active spec)
+        #[arg(short, long)]
+        spec: Option<String>,
+
+        /// Open in editor
+        #[arg(short, long)]
+        editor: bool,
+
+        /// Mark as complete
+        #[arg(long)]
+        complete: bool,
+
+        /// Export tasks to tickets
+        #[arg(long)]
+        export_tickets: bool,
+    },
+
+    /// Show specification status
+    Status {
+        /// Specification ID (defaults to active spec)
+        #[arg(short, long)]
+        spec: Option<String>,
+
+        /// Show detailed progress
+        #[arg(short, long)]
+        detailed: bool,
+    },
+
+    /// List all specifications
+    List {
+        /// Filter by status (draft, in_progress, completed, approved)
+        #[arg(short, long)]
+        status: Option<String>,
+
+        /// Filter by phase (requirements, design, tasks)
+        #[arg(long)]
+        phase: Option<String>,
+
+        /// Show archived specs
+        #[arg(long)]
+        archived: bool,
+    },
+
+    /// Show specification details
+    Show {
+        /// Specification ID
+        spec: String,
+
+        /// Show all documents
+        #[arg(short, long)]
+        all: bool,
+
+        /// Show in markdown format
+        #[arg(short, long)]
+        markdown: bool,
+    },
+
+    /// Delete a specification
+    Delete {
+        /// Specification ID
+        spec: String,
+
+        /// Force deletion without confirmation
+        #[arg(short, long)]
+        force: bool,
+    },
+
+    /// Approve a specification phase
+    Approve {
+        /// Specification ID
+        spec: String,
+
+        /// Phase to approve (requirements, design, tasks)
+        phase: String,
+
+        /// Approval message
+        #[arg(short, long)]
+        message: Option<String>,
+    },
+
+    /// Set active specification
+    Activate {
+        /// Specification ID
+        spec: String,
     },
 }

--- a/src/cli/handlers/config.rs
+++ b/src/cli/handlers/config.rs
@@ -33,6 +33,9 @@ pub fn handle_config_command(
         ConfigCommands::Set { key, value } => handle_set(&key, &value, &config_path, output),
         ConfigCommands::Get { key } => handle_get(&key, &config_path, output),
         ConfigCommands::Reset { force } => handle_reset(force, &config_path, output),
+        ConfigCommands::Claude { append, template, output: output_path } => {
+            handle_claude(append, &template, output_path, &project_root, &config_path, output)
+        }
     }
 }
 
@@ -259,6 +262,249 @@ fn set_config_value(config: &mut Config, key: &str, value: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Handle the claude subcommand for generating CLAUDE.md
+fn handle_claude(
+    append: bool,
+    template: &str,
+    output_path: Option<String>,
+    project_root: &std::path::Path,
+    config_path: &std::path::Path,
+    output: &OutputFormatter,
+) -> Result<()> {
+    use std::fs;
+    use std::path::PathBuf;
+
+    // Load config
+    let config = Config::load_from_path(config_path)?;
+
+    // Determine output path
+    let claude_path = if let Some(path) = output_path {
+        PathBuf::from(path)
+    } else {
+        project_root.join("CLAUDE.md")
+    };
+
+    // Generate content based on template
+    let content = match template {
+        "basic" => generate_basic_claude_md(&config, project_root)?,
+        "advanced" => generate_advanced_claude_md(&config, project_root)?,
+        _ => return Err(VideTicketError::custom(format!(
+            "Unknown template '{}'. Available templates: basic, advanced", 
+            template
+        ))),
+    };
+
+    // Write or append content
+    if append && claude_path.exists() {
+        let existing = fs::read_to_string(&claude_path)?;
+        let combined = format!("{}\n\n{}", existing, content);
+        fs::write(&claude_path, combined)?;
+        
+        if output.is_json() {
+            output.print_json(&serde_json::json!({
+                "action": "appended",
+                "path": claude_path.display().to_string(),
+                "template": template,
+            }))?;
+        } else {
+            output.success(&format!("Appended to CLAUDE.md at: {}", claude_path.display()));
+        }
+    } else {
+        fs::write(&claude_path, &content)?;
+        
+        if output.is_json() {
+            output.print_json(&serde_json::json!({
+                "action": "created",
+                "path": claude_path.display().to_string(),
+                "template": template,
+            }))?;
+        } else {
+            output.success(&format!("Created CLAUDE.md at: {}", claude_path.display()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Generate basic CLAUDE.md template
+fn generate_basic_claude_md(config: &Config, project_root: &std::path::Path) -> Result<String> {
+    use crate::storage::{FileStorage, TicketRepository};
+    
+    let storage = FileStorage::new(&project_root.join(".vide-ticket"));
+    let tickets = storage.load_all().unwrap_or_default();
+    let active_tickets = tickets.iter()
+        .filter(|t| matches!(t.status, crate::core::Status::Doing))
+        .count();
+
+    let content = format!(r#"# vide-ticket Project: {}
+
+{}
+
+## Overview
+
+This project uses vide-ticket for ticket management. This document provides guidance for Claude Code when working with this codebase.
+
+## Common vide-ticket Commands
+
+### Basic Operations
+```bash
+# Create a new ticket
+vide-ticket new <slug> --title "<title>" --priority <priority>
+
+# List all tickets
+vide-ticket list
+
+# Show ticket details
+vide-ticket show <ticket>
+
+# Start working on a ticket
+vide-ticket start <ticket>
+
+# Close a ticket
+vide-ticket close <ticket> --message "<completion message>"
+```
+
+### Task Management
+```bash
+# Add a task to current ticket
+vide-ticket task add "<task description>"
+
+# Complete a task
+vide-ticket task complete <task-number>
+
+# List tasks
+vide-ticket task list
+```
+
+## Current Configuration
+
+- **Project Name**: {}
+- **Default Priority**: {}
+- **Git Integration**: {}
+- **Auto Branch**: {}
+- **Emoji in Output**: {}
+
+## Project Statistics
+
+- **Total Tickets**: {}
+- **Active Tickets**: {}
+
+## Workflow Guidelines
+
+1. Always create a ticket before starting new work
+2. Use descriptive slugs for tickets (e.g., fix-login-bug, add-search-feature)
+3. Add tasks to break down complex tickets
+4. Update ticket status as work progresses
+5. Close tickets with meaningful completion messages
+
+## Best Practices
+
+- Keep ticket descriptions clear and actionable
+- Use appropriate priority levels (low, medium, high, critical)
+- Tag tickets for better organization
+- Regularly update ticket status
+- Document decisions in ticket descriptions
+
+---
+Generated on: {}
+"#,
+        config.project.name,
+        config.project.description.as_deref().unwrap_or("A vide-ticket managed project"),
+        config.project.name,
+        config.project.default_priority,
+        if config.git.enabled { "Enabled" } else { "Disabled" },
+        config.git.auto_branch,
+        config.ui.emoji,
+        tickets.len(),
+        active_tickets,
+        chrono::Local::now().format("%Y-%m-%d")
+    );
+
+    Ok(content)
+}
+
+/// Generate advanced CLAUDE.md template
+fn generate_advanced_claude_md(config: &Config, project_root: &std::path::Path) -> Result<String> {
+    let basic = generate_basic_claude_md(config, project_root)?;
+    
+    let advanced_section = format!(r#"
+## Advanced Features
+
+### Git Worktree Support
+```bash
+# Enable worktree support
+vide-ticket config set git.worktree_enabled true
+
+# Start ticket with worktree
+vide-ticket start <ticket> --worktree
+```
+
+### Search and Filter
+```bash
+# Search tickets by content
+vide-ticket search "<query>"
+
+# Filter by status
+vide-ticket list --status doing
+
+# Filter by priority
+vide-ticket list --priority high
+
+# Complex filters
+vide-ticket list --status todo --priority high --assignee me
+```
+
+### Export and Import
+```bash
+# Export tickets to JSON
+vide-ticket export json -o tickets.json
+
+# Export to CSV
+vide-ticket export csv -o tickets.csv
+
+# Import tickets
+vide-ticket import tickets.json
+```
+
+## Integration Points
+
+### Environment Variables
+- `VIDE_TICKET_PROJECT`: Override project directory
+- `VIDE_TICKET_NO_COLOR`: Disable colored output
+- `VIDE_TICKET_JSON`: Force JSON output
+
+### Git Hooks
+You can integrate vide-ticket with Git hooks for automated workflows:
+
+```bash
+# pre-commit hook example
+#!/bin/bash
+if [ -z "$(vide-ticket check --active)" ]; then
+    echo "Error: No active ticket. Start a ticket before committing."
+    exit 1
+fi
+```
+
+## Troubleshooting
+
+### Common Issues
+1. **"Project not initialized"**: Run `vide-ticket init` in the project root
+2. **"No active ticket"**: Use `vide-ticket start <ticket>` to set active ticket
+3. **"Ticket not found"**: Check ticket slug with `vide-ticket list`
+
+### Debug Mode
+```bash
+# Enable verbose output
+vide-ticket --verbose <command>
+
+# Check project status
+vide-ticket check --detailed
+```
+"#);
+
+    Ok(format!("{}\n{}", basic, advanced_section))
 }
 
 /// Format a JSON value for display

--- a/src/cli/handlers/mod.rs
+++ b/src/cli/handlers/mod.rs
@@ -34,6 +34,7 @@ mod list;
 mod new;
 mod search;
 mod show;
+mod spec;
 mod start;
 mod task;
 
@@ -51,6 +52,11 @@ pub use new::handle_new_command;
 pub use search::handle_search_command;
 pub use show::handle_show_command;
 pub use start::handle_start_command;
+pub use spec::{
+    handle_spec_activate, handle_spec_approve, handle_spec_delete, handle_spec_design,
+    handle_spec_init, handle_spec_list, handle_spec_requirements, handle_spec_show,
+    handle_spec_status, handle_spec_tasks,
+};
 pub use task::{
     handle_task_add, handle_task_complete, handle_task_list, handle_task_remove,
     handle_task_uncomplete,

--- a/src/cli/handlers/spec.rs
+++ b/src/cli/handlers/spec.rs
@@ -1,0 +1,753 @@
+//! Handlers for spec-driven development commands
+//!
+//! This module implements all handlers for specification management commands,
+//! supporting the three-phase spec-driven development workflow.
+
+use crate::cli::output::OutputFormatter;
+use crate::error::{ErrorContext, Result, VideTicketError};
+use crate::specs::{
+    SpecDocumentType, SpecManager, SpecPhase, SpecTemplate,
+    Specification, TemplateEngine,
+};
+use chrono::Utc;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+/// Handle spec init command
+pub fn handle_spec_init(
+    title: String,
+    description: Option<String>,
+    ticket: Option<String>,
+    tags: Option<String>,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    // Parse tags
+    let tag_list: Vec<String> = tags
+        .map(|t| t.split(',').map(|s| s.trim().to_string()).collect())
+        .unwrap_or_default();
+
+    // Create new specification
+    let spec = Specification::new(
+        title.clone(),
+        description.clone().unwrap_or_default(),
+        ticket,
+        tag_list,
+    );
+
+    // Save specification
+    spec_manager.save(&spec)?;
+
+    formatter.success(&format!(
+        "Created new specification '{}' with ID: {}",
+        title, spec.metadata.id
+    ));
+
+    if formatter.is_json() {
+        formatter.json(&serde_json::json!({
+            "status": "success",
+            "spec_id": spec.metadata.id,
+            "title": title,
+            "description": description,
+            "ticket_id": spec.metadata.ticket_id,
+            "tags": spec.metadata.tags,
+        }))?;
+    } else {
+        formatter.info(&format!("Specification ID: {}", spec.metadata.id));
+        if let Some(desc) = description {
+            formatter.info(&format!("Description: {}", desc));
+        }
+        if let Some(ticket_id) = &spec.metadata.ticket_id {
+            formatter.info(&format!("Associated ticket: {}", ticket_id));
+        }
+        formatter.info("\nNext steps:");
+        formatter.info("  1. Define requirements: vide-ticket spec requirements");
+        formatter.info("  2. Create design: vide-ticket spec design");
+        formatter.info("  3. Plan tasks: vide-ticket spec tasks");
+    }
+
+    Ok(())
+}
+
+/// Handle spec requirements command
+pub fn handle_spec_requirements(
+    spec: Option<String>,
+    editor: bool,
+    complete: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    // Get spec ID (from parameter or active spec)
+    let spec_id = match spec {
+        Some(id) => id,
+        None => get_active_spec(&project_dir)?,
+    };
+
+    // Load specification
+    let mut specification = spec_manager.load(&spec_id)?;
+
+    if complete {
+        // Mark requirements phase as complete
+        specification.metadata.progress.requirements_completed = true;
+        specification.metadata.updated_at = Utc::now();
+        spec_manager.save(&specification)?;
+        
+        formatter.success(&format!(
+            "Marked requirements phase as complete for spec '{}'",
+            specification.metadata.title
+        ));
+        return Ok(());
+    }
+
+    // Get or create requirements document
+    let doc_path = spec_manager.get_document_path(&spec_id, SpecDocumentType::Requirements);
+    
+    if !doc_path.exists() {
+        // Create from template
+        let mut engine = TemplateEngine::new();
+        engine.set_variable("spec_id".to_string(), spec_id.clone());
+        
+        let template = SpecTemplate::for_document_type(
+            SpecDocumentType::Requirements,
+            specification.metadata.title.clone(),
+            Some(specification.metadata.description.clone()),
+        );
+        
+        let content = engine.generate(&template);
+        fs::write(&doc_path, content).context("Failed to create requirements document")?;
+        
+        formatter.info(&format!(
+            "Created requirements document: {}",
+            doc_path.display()
+        ));
+    }
+
+    if editor {
+        // Open in editor
+        open_in_editor(&doc_path)?;
+        formatter.success("Requirements document saved");
+    } else {
+        // Display content
+        let content = fs::read_to_string(&doc_path).context("Failed to read requirements document")?;
+        formatter.info(&content);
+    }
+
+    Ok(())
+}
+
+/// Handle spec design command
+pub fn handle_spec_design(
+    spec: Option<String>,
+    editor: bool,
+    complete: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    // Get spec ID (from parameter or active spec)
+    let spec_id = match spec {
+        Some(id) => id,
+        None => get_active_spec(&project_dir)?,
+    };
+
+    // Load specification
+    let mut specification = spec_manager.load(&spec_id)?;
+
+    // Check if requirements are complete
+    if !specification.metadata.progress.requirements_completed {
+        formatter.warning("Requirements phase is not complete. Consider completing it first.");
+    }
+
+    if complete {
+        // Mark design phase as complete
+        specification.metadata.progress.design_completed = true;
+        specification.metadata.updated_at = Utc::now();
+        spec_manager.save(&specification)?;
+        
+        formatter.success(&format!(
+            "Marked design phase as complete for spec '{}'",
+            specification.metadata.title
+        ));
+        return Ok(());
+    }
+
+    // Get or create design document
+    let doc_path = spec_manager.get_document_path(&spec_id, SpecDocumentType::Design);
+    
+    if !doc_path.exists() {
+        // Create from template with requirements summary
+        let requirements_path = spec_manager.get_document_path(&spec_id, SpecDocumentType::Requirements);
+        let requirements_summary = if requirements_path.exists() {
+            // Extract summary from requirements doc
+            "See requirements document for details."
+        } else {
+            "Requirements not yet defined."
+        };
+        
+        let mut engine = TemplateEngine::new();
+        engine.set_variable("spec_id".to_string(), spec_id.clone());
+        
+        let template = SpecTemplate::for_document_type(
+            SpecDocumentType::Design,
+            specification.metadata.title.clone(),
+            Some(requirements_summary.to_string()),
+        );
+        
+        let content = engine.generate(&template);
+        fs::write(&doc_path, content).context("Failed to create design document")?;
+        
+        formatter.info(&format!(
+            "Created design document: {}",
+            doc_path.display()
+        ));
+    }
+
+    if editor {
+        // Open in editor
+        open_in_editor(&doc_path)?;
+        formatter.success("Design document saved");
+    } else {
+        // Display content
+        let content = fs::read_to_string(&doc_path).context("Failed to read design document")?;
+        formatter.info(&content);
+    }
+
+    Ok(())
+}
+
+/// Handle spec tasks command
+pub fn handle_spec_tasks(
+    spec: Option<String>,
+    editor: bool,
+    complete: bool,
+    export_tickets: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    // Get spec ID (from parameter or active spec)
+    let spec_id = match spec {
+        Some(id) => id,
+        None => get_active_spec(&project_dir)?,
+    };
+
+    // Load specification
+    let mut specification = spec_manager.load(&spec_id)?;
+
+    // Check if design is complete
+    if !specification.metadata.progress.design_completed {
+        formatter.warning("Design phase is not complete. Consider completing it first.");
+    }
+
+    if complete {
+        // Mark tasks phase as complete
+        specification.metadata.progress.tasks_completed = true;
+        specification.metadata.updated_at = Utc::now();
+        spec_manager.save(&specification)?;
+        
+        formatter.success(&format!(
+            "Marked tasks phase as complete for spec '{}'",
+            specification.metadata.title
+        ));
+        return Ok(());
+    }
+
+    // Get or create tasks document
+    let doc_path = spec_manager.get_document_path(&spec_id, SpecDocumentType::Tasks);
+    
+    if !doc_path.exists() {
+        // Create from template with design summary
+        let design_path = spec_manager.get_document_path(&spec_id, SpecDocumentType::Design);
+        let design_summary = if design_path.exists() {
+            "See design document for technical details."
+        } else {
+            "Design not yet defined."
+        };
+        
+        let mut engine = TemplateEngine::new();
+        engine.set_variable("spec_id".to_string(), spec_id.clone());
+        
+        let template = SpecTemplate::for_document_type(
+            SpecDocumentType::Tasks,
+            specification.metadata.title.clone(),
+            Some(design_summary.to_string()),
+        );
+        
+        let content = engine.generate(&template);
+        fs::write(&doc_path, content).context("Failed to create tasks document")?;
+        
+        formatter.info(&format!(
+            "Created tasks document: {}",
+            doc_path.display()
+        ));
+    }
+
+    if export_tickets {
+        // TODO: Implement task export to tickets
+        formatter.warning("Task export to tickets is not yet implemented");
+    }
+
+    if editor {
+        // Open in editor
+        open_in_editor(&doc_path)?;
+        formatter.success("Tasks document saved");
+    } else {
+        // Display content
+        let content = fs::read_to_string(&doc_path).context("Failed to read tasks document")?;
+        formatter.info(&content);
+    }
+
+    Ok(())
+}
+
+/// Handle spec status command
+pub fn handle_spec_status(
+    spec: Option<String>,
+    detailed: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    // Get spec ID (from parameter or active spec)
+    let spec_id = match spec {
+        Some(id) => id,
+        None => get_active_spec(&project_dir)?,
+    };
+
+    // Load specification
+    let specification = spec_manager.load(&spec_id)?;
+
+    if formatter.is_json() {
+        formatter.json(&serde_json::json!({
+            "spec_id": specification.metadata.id,
+            "title": specification.metadata.title,
+            "status": format!("{:?}", specification.metadata.progress.current_phase()),
+            "progress": {
+                "requirements": specification.metadata.progress.requirements_completed,
+                "design": specification.metadata.progress.design_completed,
+                "tasks": specification.metadata.progress.tasks_completed,
+            },
+            "approval": specification.metadata.progress.approval_status,
+        }))?;
+    } else {
+        formatter.info(&format!(
+            "Specification: {} ({})",
+            specification.metadata.title, specification.metadata.id
+        ));
+        formatter.info(&format!(
+            "Current Phase: {:?}",
+            specification.metadata.progress.current_phase()
+        ));
+        
+        formatter.info("\nProgress:");
+        formatter.info(&format!(
+            "  Requirements: {}",
+            if specification.metadata.progress.requirements_completed { "✓ Complete" } else { "○ In Progress" }
+        ));
+        formatter.info(&format!(
+            "  Design: {}",
+            if specification.metadata.progress.design_completed { "✓ Complete" } else { "○ Pending" }
+        ));
+        formatter.info(&format!(
+            "  Tasks: {}",
+            if specification.metadata.progress.tasks_completed { "✓ Complete" } else { "○ Pending" }
+        ));
+
+        if detailed {
+            formatter.info(&format!("\nCreated: {}", specification.metadata.created_at));
+            formatter.info(&format!("Updated: {}", specification.metadata.updated_at));
+            if let Some(ticket_id) = &specification.metadata.ticket_id {
+                formatter.info(&format!("Ticket: {}", ticket_id));
+            }
+            if !specification.metadata.tags.is_empty() {
+                formatter.info(&format!("Tags: {}", specification.metadata.tags.join(", ")));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle spec list command
+pub fn handle_spec_list(
+    status: Option<String>,
+    phase: Option<String>,
+    _archived: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+    let specs = spec_manager.list()?;
+
+    // Filter specs
+    let filtered_specs: Vec<_> = specs
+        .into_iter()
+        .filter(|spec| {
+            // Filter by status if provided
+            if let Some(ref status_filter) = status {
+                let current_status = format!("{:?}", spec.metadata.progress.current_phase()).to_lowercase();
+                if !current_status.contains(&status_filter.to_lowercase()) {
+                    return false;
+                }
+            }
+            
+            // Filter by phase if provided
+            if let Some(ref phase_filter) = phase {
+                match phase_filter.to_lowercase().as_str() {
+                    "requirements" => {
+                        if spec.metadata.progress.requirements_completed {
+                            return false;
+                        }
+                    }
+                    "design" => {
+                        if !spec.metadata.progress.requirements_completed || spec.metadata.progress.design_completed {
+                            return false;
+                        }
+                    }
+                    "tasks" => {
+                        if !spec.metadata.progress.design_completed || spec.metadata.progress.tasks_completed {
+                            return false;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            
+            true
+        })
+        .collect();
+
+    if formatter.is_json() {
+        let specs_json: Vec<_> = filtered_specs
+            .iter()
+            .map(|spec| {
+                serde_json::json!({
+                    "id": spec.metadata.id,
+                    "title": spec.metadata.title,
+                    "description": spec.metadata.description,
+                    "phase": format!("{:?}", spec.metadata.progress.current_phase()),
+                    "created_at": spec.metadata.created_at,
+                    "updated_at": spec.metadata.updated_at,
+                })
+            })
+            .collect();
+        formatter.json(&serde_json::json!(specs_json))?;
+    } else {
+        if filtered_specs.is_empty() {
+            formatter.info("No specifications found");
+        } else {
+            formatter.info(&format!("Found {} specification(s):\n", filtered_specs.len()));
+            
+            for spec in &filtered_specs {
+                formatter.info(&format!(
+                    "{} - {} ({:?})",
+                    spec.metadata.id,
+                    spec.metadata.title,
+                    spec.metadata.progress.current_phase()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle spec show command
+pub fn handle_spec_show(
+    spec: String,
+    all: bool,
+    markdown: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+    let specification = spec_manager.load(&spec)?;
+
+    if formatter.is_json() {
+        formatter.json(&serde_json::json!(specification))?;
+    } else {
+        formatter.info(&format!("# Specification: {}", specification.metadata.title));
+        formatter.info(&format!("ID: {}", specification.metadata.id));
+        formatter.info(&format!("Description: {}", specification.metadata.description));
+        formatter.info(&format!("Phase: {:?}", specification.metadata.progress.current_phase()));
+        
+        if all || markdown {
+            // Show all documents
+            let doc_types = [
+                SpecDocumentType::Requirements,
+                SpecDocumentType::Design,
+                SpecDocumentType::Tasks,
+            ];
+            
+            for doc_type in &doc_types {
+                let doc_path = spec_manager.get_document_path(&spec, *doc_type);
+                if doc_path.exists() {
+                    formatter.info(&format!("\n## {:?} Document\n", doc_type));
+                    let content = fs::read_to_string(&doc_path)
+                        .context("Failed to read document")?;
+                    formatter.info(&content);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle spec delete command
+pub fn handle_spec_delete(
+    spec: String,
+    force: bool,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+
+    if !force {
+        // Confirm deletion
+        formatter.warning(&format!("Are you sure you want to delete specification '{}'?", spec));
+        formatter.warning("This will delete all associated documents and cannot be undone.");
+        formatter.info("Use --force to skip this confirmation.");
+        return Ok(());
+    }
+
+    spec_manager.delete(&spec)?;
+    formatter.success(&format!("Deleted specification '{}'", spec));
+
+    Ok(())
+}
+
+/// Handle spec approve command
+pub fn handle_spec_approve(
+    spec: String,
+    phase: String,
+    message: Option<String>,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+    let mut specification = spec_manager.load(&spec)?;
+
+    // Parse phase
+    let phase_enum = match phase.to_lowercase().as_str() {
+        "requirements" => SpecPhase::Requirements,
+        "design" => SpecPhase::Design,
+        "tasks" => SpecPhase::Tasks,
+        _ => {
+            return Err(VideTicketError::InvalidInput(
+                "Invalid phase. Must be one of: requirements, design, tasks".to_string(),
+            ));
+        }
+    };
+
+    // Update approval status
+    if specification.metadata.progress.approval_status.is_none() {
+        specification.metadata.progress.approval_status = Some(std::collections::HashMap::new());
+    }
+    
+    if let Some(ref mut approvals) = specification.metadata.progress.approval_status {
+        approvals.insert(
+            format!("{:?}", phase_enum),
+            serde_json::json!({
+                "approved": true,
+                "approved_at": Utc::now(),
+                "message": message,
+            }),
+        );
+    }
+
+    specification.metadata.updated_at = Utc::now();
+    spec_manager.save(&specification)?;
+
+    formatter.success(&format!(
+        "Approved {} phase for specification '{}'",
+        phase, specification.metadata.title
+    ));
+
+    Ok(())
+}
+
+/// Handle spec activate command
+pub fn handle_spec_activate(
+    spec: String,
+    project: Option<String>,
+    formatter: &OutputFormatter,
+) -> Result<()> {
+    // Change to project directory if specified
+    if let Some(project_path) = project {
+        std::env::set_current_dir(&project_path)
+            .with_context(|| format!("Failed to change to project directory: {}", project_path))?;
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let project_dir = current_dir.join(".vide-ticket");
+
+    if !project_dir.exists() {
+        return Err(VideTicketError::ProjectNotInitialized);
+    }
+
+    // Verify spec exists
+    let spec_manager = SpecManager::new(project_dir.join("specs"));
+    let specification = spec_manager.load(&spec)?;
+
+    // Save active spec
+    let active_spec_path = project_dir.join(".active_spec");
+    fs::write(&active_spec_path, &spec).context("Failed to set active specification")?;
+
+    formatter.success(&format!(
+        "Set active specification to '{}' ({})",
+        specification.metadata.title, spec
+    ));
+
+    Ok(())
+}
+
+/// Get the active specification ID
+fn get_active_spec(project_dir: &Path) -> Result<String> {
+    let active_spec_path = project_dir.join(".active_spec");
+    
+    if !active_spec_path.exists() {
+        return Err(VideTicketError::NoActiveSpec);
+    }
+    
+    fs::read_to_string(&active_spec_path)
+        .context("Failed to read active specification")
+        .map(|s| s.trim().to_string())
+}
+
+/// Open a file in the default editor
+fn open_in_editor(path: &Path) -> Result<()> {
+    let editor = env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    
+    std::process::Command::new(&editor)
+        .arg(path)
+        .status()
+        .with_context(|| format!("Failed to open editor: {}", editor))?;
+    
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,6 @@ pub mod handlers;
 mod output;
 mod utils;
 
-pub use commands::{Cli, Commands, ConfigCommands, TaskCommands};
+pub use commands::{Cli, Commands, ConfigCommands, SpecCommands, TaskCommands};
 pub use output::{OutputFormatter, ProgressBar};
 pub use utils::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,18 @@ pub enum VideTicketError {
     #[error("UUID error: {0}")]
     Uuid(#[from] uuid::Error),
 
+    /// Specification not found
+    #[error("Specification not found: {id}")]
+    SpecNotFound { id: String },
+
+    /// No active specification
+    #[error("No active specification. Use 'vide-ticket spec activate <id>' to set active spec")]
+    NoActiveSpec,
+
+    /// Invalid input
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
     /// Generic error with custom message
     #[error("{0}")]
     Custom(String),
@@ -149,6 +161,14 @@ impl VideTicketError {
             Self::DuplicateTicket { slug } => vec![
                 format!("Use a different slug or check existing ticket '{}'", slug),
                 "Run 'vide-ticket list' to see all tickets".to_string(),
+            ],
+            Self::NoActiveSpec => vec![
+                "Run 'vide-ticket spec list' to see available specifications".to_string(),
+                "Run 'vide-ticket spec activate <id>' to set an active specification".to_string(),
+            ],
+            Self::SpecNotFound { id } => vec![
+                format!("Check if specification '{}' exists", id),
+                "Run 'vide-ticket spec list' to see all specifications".to_string(),
             ],
             _ => vec![],
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod core;
 pub mod error;
 pub mod plugins;
+pub mod specs;
 pub mod storage;
 
 #[cfg(feature = "api")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 
 use clap::Parser;
 use std::process;
-use vide_ticket::cli::{handlers::handle_init, Cli, Commands, OutputFormatter, TaskCommands};
+use vide_ticket::cli::{handlers::handle_init, Cli, Commands, OutputFormatter, SpecCommands, TaskCommands};
 use vide_ticket::error::Result;
 
 /// Main entry point for the vide-ticket CLI
@@ -58,7 +58,8 @@ fn run(cli: Cli, formatter: &OutputFormatter) -> Result<()> {
             name,
             description,
             force,
-        } => handle_init(name, description, force, formatter),
+            claude_md,
+        } => handle_init(name, description, force, claude_md, formatter),
 
         Commands::New {
             slug,
@@ -251,6 +252,49 @@ fn run(cli: Cli, formatter: &OutputFormatter) -> Result<()> {
         Commands::Config { command } => {
             use vide_ticket::cli::handlers::handle_config_command;
             handle_config_command(command, cli.project, &formatter)
+        },
+
+        Commands::Spec { command } => match command {
+            SpecCommands::Init { title, description, ticket, tags } => {
+                use vide_ticket::cli::handlers::handle_spec_init;
+                handle_spec_init(title, description, ticket, tags, cli.project, &formatter)
+            },
+            SpecCommands::Requirements { spec, editor, complete } => {
+                use vide_ticket::cli::handlers::handle_spec_requirements;
+                handle_spec_requirements(spec, editor, complete, cli.project, &formatter)
+            },
+            SpecCommands::Design { spec, editor, complete } => {
+                use vide_ticket::cli::handlers::handle_spec_design;
+                handle_spec_design(spec, editor, complete, cli.project, &formatter)
+            },
+            SpecCommands::Tasks { spec, editor, complete, export_tickets } => {
+                use vide_ticket::cli::handlers::handle_spec_tasks;
+                handle_spec_tasks(spec, editor, complete, export_tickets, cli.project, &formatter)
+            },
+            SpecCommands::Status { spec, detailed } => {
+                use vide_ticket::cli::handlers::handle_spec_status;
+                handle_spec_status(spec, detailed, cli.project, &formatter)
+            },
+            SpecCommands::List { status, phase, archived } => {
+                use vide_ticket::cli::handlers::handle_spec_list;
+                handle_spec_list(status, phase, archived, cli.project, &formatter)
+            },
+            SpecCommands::Show { spec, all, markdown } => {
+                use vide_ticket::cli::handlers::handle_spec_show;
+                handle_spec_show(spec, all, markdown, cli.project, &formatter)
+            },
+            SpecCommands::Delete { spec, force } => {
+                use vide_ticket::cli::handlers::handle_spec_delete;
+                handle_spec_delete(spec, force, cli.project, &formatter)
+            },
+            SpecCommands::Approve { spec, phase, message } => {
+                use vide_ticket::cli::handlers::handle_spec_approve;
+                handle_spec_approve(spec, phase, message, cli.project, &formatter)
+            },
+            SpecCommands::Activate { spec } => {
+                use vide_ticket::cli::handlers::handle_spec_activate;
+                handle_spec_activate(spec, cli.project, &formatter)
+            },
         },
     }
 }

--- a/src/specs/manager.rs
+++ b/src/specs/manager.rs
@@ -1,0 +1,391 @@
+//! Specification manager for handling spec lifecycle
+//!
+//! This module provides the core functionality for managing specifications,
+//! including creation, loading, saving, and version control.
+
+use super::{SpecDocumentType, SpecMetadata, SpecPhase, Specification};
+use crate::error::{ErrorContext, Result, VideTicketError};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Manages specifications in a project
+pub struct SpecManager {
+    /// Root directory for specs (.vide-ticket/specs)
+    specs_dir: PathBuf,
+}
+
+impl SpecManager {
+    /// Create a new spec manager
+    pub fn new(specs_dir: PathBuf) -> Self {
+        Self { specs_dir }
+    }
+    
+    /// Initialize the specs directory structure
+    pub fn initialize(&self) -> Result<()> {
+        fs::create_dir_all(&self.specs_dir)
+            .with_context(|| format!("Failed to create specs directory: {:?}", self.specs_dir))?;
+        
+        Ok(())
+    }
+    
+    /// Create a new specification
+    pub fn create_spec(&self, title: String, description: String) -> Result<SpecMetadata> {
+        self.initialize()?;
+        
+        let metadata = SpecMetadata::new(title, description);
+        let spec_dir = self.get_spec_dir(&metadata.id);
+        
+        // Create spec directory
+        fs::create_dir_all(&spec_dir)
+            .with_context(|| format!("Failed to create spec directory: {:?}", spec_dir))?;
+        
+        // Save initial metadata
+        self.save_metadata(&metadata)?;
+        
+        Ok(metadata)
+    }
+    
+    /// Load a specification by ID
+    pub fn load_spec(&self, spec_id: &str) -> Result<Specification> {
+        let metadata = self.load_metadata(spec_id)?;
+        let spec_dir = self.get_spec_dir(spec_id);
+        
+        // Load document contents
+        let requirements = self.load_document(&spec_dir, SpecDocumentType::Requirements)?;
+        let design = self.load_document(&spec_dir, SpecDocumentType::Design)?;
+        let tasks = self.load_document(&spec_dir, SpecDocumentType::Tasks)?;
+        
+        Ok(Specification {
+            metadata,
+            requirements,
+            design,
+            tasks,
+        })
+    }
+    
+    /// Save a document for a specification
+    pub fn save_document(
+        &self,
+        spec_id: &str,
+        doc_type: SpecDocumentType,
+        content: &str,
+    ) -> Result<()> {
+        let spec_dir = self.get_spec_dir(spec_id);
+        let doc_path = spec_dir.join(doc_type.file_name());
+        
+        // Ensure directory exists
+        fs::create_dir_all(&spec_dir)
+            .with_context(|| format!("Failed to create spec directory: {:?}", spec_dir))?;
+        
+        // Save document
+        fs::write(&doc_path, content)
+            .with_context(|| format!("Failed to write document: {:?}", doc_path))?;
+        
+        // Update metadata
+        let mut metadata = self.load_metadata(spec_id)?;
+        match doc_type {
+            SpecDocumentType::Requirements => {
+                metadata.progress.requirements_completed = true;
+                metadata.version.bump_patch();
+            }
+            SpecDocumentType::Design => {
+                metadata.progress.design_completed = true;
+                metadata.version.bump_patch();
+            }
+            SpecDocumentType::Tasks => {
+                metadata.progress.tasks_completed = true;
+                metadata.version.bump_patch();
+            }
+        }
+        metadata.update_phase();
+        self.save_metadata(&metadata)?;
+        
+        Ok(())
+    }
+    
+    /// List all specifications
+    pub fn list_specs(&self) -> Result<Vec<SpecMetadata>> {
+        if !self.specs_dir.exists() {
+            return Ok(Vec::new());
+        }
+        
+        let mut specs = Vec::new();
+        
+        let entries = fs::read_dir(&self.specs_dir)
+            .with_context(|| format!("Failed to read specs directory: {:?}", self.specs_dir))?;
+        
+        for entry in entries {
+            let entry = entry.context("Failed to read directory entry")?;
+            let path = entry.path();
+            
+            if path.is_dir() {
+                let spec_json_path = path.join("spec.json");
+                if spec_json_path.exists() {
+                    match self.load_metadata_from_path(&spec_json_path) {
+                        Ok(metadata) => specs.push(metadata),
+                        Err(e) => {
+                            eprintln!("Warning: Failed to load spec from {:?}: {}", path, e);
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Sort by creation date (newest first)
+        specs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        
+        Ok(specs)
+    }
+    
+    /// Approve a document phase
+    pub fn approve_phase(&self, spec_id: &str, phase: SpecPhase) -> Result<()> {
+        let mut metadata = self.load_metadata(spec_id)?;
+        
+        match phase {
+            SpecPhase::Requirements => {
+                if !metadata.progress.requirements_completed {
+                    return Err(VideTicketError::custom(
+                        "Cannot approve requirements: document not completed",
+                    ));
+                }
+                metadata.progress.requirements_approved = true;
+            }
+            SpecPhase::Design => {
+                if !metadata.progress.design_completed {
+                    return Err(VideTicketError::custom(
+                        "Cannot approve design: document not completed",
+                    ));
+                }
+                metadata.progress.design_approved = true;
+            }
+            SpecPhase::Implementation => {
+                if !metadata.progress.tasks_completed {
+                    return Err(VideTicketError::custom(
+                        "Cannot approve tasks: document not completed",
+                    ));
+                }
+                metadata.progress.tasks_approved = true;
+            }
+            _ => {
+                return Err(VideTicketError::custom(
+                    "Invalid phase for approval",
+                ));
+            }
+        }
+        
+        metadata.update_phase();
+        self.save_metadata(&metadata)?;
+        
+        Ok(())
+    }
+    
+    /// Get the directory path for a spec
+    fn get_spec_dir(&self, spec_id: &str) -> PathBuf {
+        self.specs_dir.join(spec_id)
+    }
+    
+    /// Load metadata for a spec
+    fn load_metadata(&self, spec_id: &str) -> Result<SpecMetadata> {
+        let spec_json_path = self.get_spec_dir(spec_id).join("spec.json");
+        self.load_metadata_from_path(&spec_json_path)
+    }
+    
+    /// Load metadata from a specific path
+    fn load_metadata_from_path(&self, path: &Path) -> Result<SpecMetadata> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read spec metadata: {:?}", path))?;
+        
+        let metadata: SpecMetadata = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse spec metadata: {:?}", path))?;
+        
+        Ok(metadata)
+    }
+    
+    /// Save metadata for a spec
+    fn save_metadata(&self, metadata: &SpecMetadata) -> Result<()> {
+        let spec_dir = self.get_spec_dir(&metadata.id);
+        
+        // Ensure spec directory exists
+        fs::create_dir_all(&spec_dir)
+            .with_context(|| format!("Failed to create spec directory: {:?}", spec_dir))?;
+        
+        let spec_json_path = spec_dir.join("spec.json");
+        let content = serde_json::to_string_pretty(metadata)
+            .context("Failed to serialize spec metadata")?;
+        
+        fs::write(&spec_json_path, content)
+            .with_context(|| format!("Failed to write spec metadata: {:?}", spec_json_path))?;
+        
+        Ok(())
+    }
+    
+    /// Load a document from a spec directory
+    fn load_document(
+        &self,
+        spec_dir: &Path,
+        doc_type: SpecDocumentType,
+    ) -> Result<Option<String>> {
+        let doc_path = spec_dir.join(doc_type.file_name());
+        
+        if !doc_path.exists() {
+            return Ok(None);
+        }
+        
+        let content = fs::read_to_string(&doc_path)
+            .with_context(|| format!("Failed to read document: {:?}", doc_path))?;
+        
+        Ok(Some(content))
+    }
+    
+    /// Find spec by title (partial match)
+    pub fn find_spec_by_title(&self, query: &str) -> Result<Option<SpecMetadata>> {
+        let specs = self.list_specs()?;
+        let query_lower = query.to_lowercase();
+        
+        Ok(specs.into_iter().find(|spec| {
+            spec.title.to_lowercase().contains(&query_lower)
+        }))
+    }
+    
+    /// Delete a specification
+    pub fn delete_spec(&self, spec_id: &str) -> Result<()> {
+        let spec_dir = self.get_spec_dir(spec_id);
+        
+        if !spec_dir.exists() {
+            return Err(VideTicketError::custom(format!(
+                "Spec not found: {}",
+                spec_id
+            )));
+        }
+        
+        fs::remove_dir_all(&spec_dir)
+            .with_context(|| format!("Failed to delete spec directory: {:?}", spec_dir))?;
+        
+        Ok(())
+    }
+
+    // Convenience methods for the handlers
+    
+    /// Save a specification
+    pub fn save(&self, spec: &Specification) -> Result<()> {
+        // Save metadata
+        self.save_metadata(&spec.metadata)?;
+        
+        // Save documents if they exist
+        if let Some(ref content) = spec.requirements {
+            self.save_document(&spec.metadata.id, SpecDocumentType::Requirements, content)?;
+        }
+        if let Some(ref content) = spec.design {
+            self.save_document(&spec.metadata.id, SpecDocumentType::Design, content)?;
+        }
+        if let Some(ref content) = spec.tasks {
+            self.save_document(&spec.metadata.id, SpecDocumentType::Tasks, content)?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Load a specification
+    pub fn load(&self, spec_id: &str) -> Result<Specification> {
+        self.load_spec(spec_id)
+    }
+    
+    /// List all specifications
+    pub fn list(&self) -> Result<Vec<Specification>> {
+        let metadata_list = self.list_specs()?;
+        let mut specs = Vec::new();
+        
+        for metadata in metadata_list {
+            match self.load_spec(&metadata.id) {
+                Ok(spec) => specs.push(spec),
+                Err(e) => {
+                    eprintln!("Warning: Failed to load spec {}: {}", metadata.id, e);
+                }
+            }
+        }
+        
+        Ok(specs)
+    }
+    
+    /// Delete a specification
+    pub fn delete(&self, spec_id: &str) -> Result<()> {
+        self.delete_spec(spec_id)
+    }
+    
+    /// Get the path for a document
+    pub fn get_document_path(&self, spec_id: &str, doc_type: SpecDocumentType) -> PathBuf {
+        self.get_spec_dir(spec_id).join(doc_type.file_name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn test_spec_manager_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let specs_dir = temp_dir.path().join(".vide-ticket/specs");
+        let manager = SpecManager::new(specs_dir.clone());
+        
+        assert_eq!(
+            manager.specs_dir,
+            specs_dir
+        );
+    }
+    
+    #[test]
+    fn test_create_and_load_spec() {
+        let temp_dir = TempDir::new().unwrap();
+        let specs_dir = temp_dir.path().join(".vide-ticket/specs");
+        let manager = SpecManager::new(specs_dir);
+        
+        // Create spec
+        let metadata = manager
+            .create_spec("Test Spec".to_string(), "Test description".to_string())
+            .unwrap();
+        
+        assert_eq!(metadata.title, "Test Spec");
+        assert_eq!(metadata.description, "Test description");
+        assert_eq!(metadata.progress.current_phase, SpecPhase::Initial);
+        
+        // Load spec
+        let spec = manager.load_spec(&metadata.id).unwrap();
+        assert_eq!(spec.metadata.title, "Test Spec");
+        assert!(spec.requirements.is_none());
+        assert!(spec.design.is_none());
+        assert!(spec.tasks.is_none());
+    }
+    
+    #[test]
+    fn test_save_and_load_documents() {
+        let temp_dir = TempDir::new().unwrap();
+        let specs_dir = temp_dir.path().join(".vide-ticket/specs");
+        let manager = SpecManager::new(specs_dir);
+        
+        // Create spec
+        let metadata = manager
+            .create_spec("Test Spec".to_string(), "Test description".to_string())
+            .unwrap();
+        
+        // Save requirements
+        manager
+            .save_document(
+                &metadata.id,
+                SpecDocumentType::Requirements,
+                "# Requirements\nTest requirements",
+            )
+            .unwrap();
+        
+        // Load spec and verify
+        let spec = manager.load_spec(&metadata.id).unwrap();
+        assert!(spec.requirements.is_some());
+        assert_eq!(
+            spec.requirements.unwrap(),
+            "# Requirements\nTest requirements"
+        );
+        assert!(spec.metadata.progress.requirements_completed);
+        assert_eq!(spec.metadata.progress.current_phase, SpecPhase::Design);
+    }
+}

--- a/src/specs/mod.rs
+++ b/src/specs/mod.rs
@@ -1,0 +1,298 @@
+//! Spec-Driven Development (仕様駆動開発) module
+//!
+//! This module implements a specification-driven development workflow inspired by Kiro.
+//! It manages three types of documents:
+//! - Requirements Definition (要件定義書)
+//! - Technical Design (技術設計書)
+//! - Implementation Plan (実装計画書)
+//!
+//! # Architecture
+//!
+//! The specs are stored as Markdown files in `.vide-ticket/specs/` directory
+//! with a `spec.json` file tracking the progress and metadata.
+//!
+//! # Workflow
+//!
+//! 1. Initialize a new spec
+//! 2. Create requirements definition
+//! 3. Create technical design based on requirements
+//! 4. Create implementation plan based on design
+//! 5. Track progress through spec.json
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+pub mod manager;
+pub mod templates;
+
+pub use manager::SpecManager;
+pub use templates::{SpecTemplate, TemplateEngine};
+
+/// Specification metadata and progress tracking
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecMetadata {
+    /// Unique spec ID
+    pub id: String,
+    
+    /// Spec title
+    pub title: String,
+    
+    /// Brief description
+    pub description: String,
+    
+    /// Associated ticket ID (if any)
+    pub ticket_id: Option<String>,
+    
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    
+    /// Last update timestamp
+    pub updated_at: DateTime<Utc>,
+    
+    /// Progress tracking
+    pub progress: SpecProgress,
+    
+    /// Version information
+    pub version: SpecVersion,
+    
+    /// Tags for categorization
+    pub tags: Vec<String>,
+}
+
+/// Progress tracking for spec documents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecProgress {
+    /// Requirements definition completed
+    pub requirements_completed: bool,
+    
+    /// Technical design completed
+    pub design_completed: bool,
+    
+    /// Implementation plan completed
+    pub tasks_completed: bool,
+    
+    /// Requirements approval status
+    pub requirements_approved: bool,
+    
+    /// Design approval status
+    pub design_approved: bool,
+    
+    /// Tasks approval status
+    pub tasks_approved: bool,
+    
+    /// Current phase
+    pub current_phase: SpecPhase,
+    
+    /// Approval status with additional metadata
+    pub approval_status: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+/// Current phase of the specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpecPhase {
+    /// Initial phase - no documents created yet
+    Initial,
+    
+    /// Requirements definition phase
+    Requirements,
+    
+    /// Technical design phase
+    Design,
+    
+    /// Implementation planning phase
+    Implementation,
+    
+    /// Tasks phase (alias for Implementation)
+    Tasks,
+    
+    /// All phases completed
+    Completed,
+}
+
+/// Version information for spec documents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecVersion {
+    /// Major version (breaking changes)
+    pub major: u32,
+    
+    /// Minor version (new features)
+    pub minor: u32,
+    
+    /// Patch version (bug fixes)
+    pub patch: u32,
+}
+
+/// Specification document type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecDocumentType {
+    /// Requirements definition document
+    Requirements,
+    
+    /// Technical design document
+    Design,
+    
+    /// Implementation plan/tasks document
+    Tasks,
+}
+
+
+/// A complete specification with all documents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Specification {
+    /// Metadata
+    pub metadata: SpecMetadata,
+    
+    /// Requirements definition content
+    pub requirements: Option<String>,
+    
+    /// Technical design content
+    pub design: Option<String>,
+    
+    /// Implementation plan content
+    pub tasks: Option<String>,
+}
+
+impl Specification {
+    /// Create a new specification
+    pub fn new(
+        title: String,
+        description: String,
+        ticket_id: Option<String>,
+        tags: Vec<String>,
+    ) -> Self {
+        let mut metadata = SpecMetadata::new(title, description);
+        metadata.ticket_id = ticket_id;
+        metadata.tags = tags;
+        
+        Self {
+            metadata,
+            requirements: None,
+            design: None,
+            tasks: None,
+        }
+    }
+}
+
+impl SpecMetadata {
+    /// Create new spec metadata
+    pub fn new(title: String, description: String) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            title,
+            description,
+            ticket_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            progress: SpecProgress::default(),
+            version: SpecVersion::default(),
+            tags: Vec::new(),
+        }
+    }
+    
+    /// Update the current phase based on progress
+    pub fn update_phase(&mut self) {
+        self.progress.current_phase = match (
+            self.progress.requirements_completed,
+            self.progress.design_completed,
+            self.progress.tasks_completed,
+        ) {
+            (false, _, _) => SpecPhase::Requirements,
+            (true, false, _) => SpecPhase::Design,
+            (true, true, false) => SpecPhase::Implementation,
+            (true, true, true) => SpecPhase::Completed,
+        };
+        self.updated_at = Utc::now();
+    }
+}
+
+impl SpecProgress {
+    /// Get the current phase
+    pub fn current_phase(&self) -> SpecPhase {
+        self.current_phase
+    }
+}
+
+impl Default for SpecProgress {
+    fn default() -> Self {
+        Self {
+            requirements_completed: false,
+            design_completed: false,
+            tasks_completed: false,
+            requirements_approved: false,
+            design_approved: false,
+            tasks_approved: false,
+            current_phase: SpecPhase::Initial,
+            approval_status: None,
+        }
+    }
+}
+
+impl Default for SpecVersion {
+    fn default() -> Self {
+        Self {
+            major: 0,
+            minor: 1,
+            patch: 0,
+        }
+    }
+}
+
+impl SpecVersion {
+    /// Get version string
+    pub fn to_string(&self) -> String {
+        format!("{}.{}.{}", self.major, self.minor, self.patch)
+    }
+    
+    /// Increment patch version
+    pub fn bump_patch(&mut self) {
+        self.patch += 1;
+    }
+    
+    /// Increment minor version (resets patch)
+    pub fn bump_minor(&mut self) {
+        self.minor += 1;
+        self.patch = 0;
+    }
+    
+    /// Increment major version (resets minor and patch)
+    pub fn bump_major(&mut self) {
+        self.major += 1;
+        self.minor = 0;
+        self.patch = 0;
+    }
+}
+
+impl SpecDocumentType {
+    /// Get file name for this document type
+    pub fn file_name(&self) -> &'static str {
+        match self {
+            Self::Requirements => "requirements.md",
+            Self::Design => "design.md",
+            Self::Tasks => "tasks.md",
+        }
+    }
+    
+    /// Get display name
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::Requirements => "Requirements Definition",
+            Self::Design => "Technical Design",
+            Self::Tasks => "Implementation Plan",
+        }
+    }
+}
+
+impl std::fmt::Display for SpecPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Initial => write!(f, "Initial"),
+            Self::Requirements => write!(f, "Requirements Definition"),
+            Self::Design => write!(f, "Technical Design"),
+            Self::Implementation => write!(f, "Implementation Planning"),
+            Self::Tasks => write!(f, "Tasks"),
+            Self::Completed => write!(f, "Completed"),
+        }
+    }
+}

--- a/src/specs/templates.rs
+++ b/src/specs/templates.rs
@@ -1,0 +1,426 @@
+//! Template engine for spec documents
+//!
+//! This module provides templates for generating initial content
+//! for requirements, design, and implementation documents.
+
+use super::SpecDocumentType;
+use chrono::Local;
+use std::collections::HashMap;
+
+/// Template engine for generating spec documents
+pub struct TemplateEngine {
+    /// Template variables
+    variables: HashMap<String, String>,
+}
+
+impl TemplateEngine {
+    /// Create a new template engine
+    pub fn new() -> Self {
+        let mut variables = HashMap::new();
+        variables.insert("date".to_string(), Local::now().format("%Y-%m-%d").to_string());
+        
+        Self { variables }
+    }
+    
+    /// Set a template variable
+    pub fn set_variable(&mut self, key: String, value: String) {
+        self.variables.insert(key, value);
+    }
+    
+    /// Generate document from template
+    pub fn generate(&self, template: &SpecTemplate) -> String {
+        let mut content = template.content();
+        
+        // Replace variables
+        for (key, value) in &self.variables {
+            let placeholder = format!("{{{{{}}}}}", key);
+            content = content.replace(&placeholder, value);
+        }
+        
+        content
+    }
+}
+
+/// Specification document template
+pub enum SpecTemplate {
+    /// Requirements definition template
+    Requirements {
+        title: String,
+        description: String,
+    },
+    
+    /// Technical design template
+    Design {
+        title: String,
+        requirements_summary: String,
+    },
+    
+    /// Implementation plan template
+    Tasks {
+        title: String,
+        design_summary: String,
+    },
+}
+
+impl SpecTemplate {
+    /// Create a template for a document type
+    pub fn for_document_type(
+        doc_type: SpecDocumentType,
+        title: String,
+        context: Option<String>,
+    ) -> Self {
+        match doc_type {
+            SpecDocumentType::Requirements => Self::Requirements {
+                title,
+                description: context.unwrap_or_default(),
+            },
+            SpecDocumentType::Design => Self::Design {
+                title,
+                requirements_summary: context.unwrap_or_default(),
+            },
+            SpecDocumentType::Tasks => Self::Tasks {
+                title,
+                design_summary: context.unwrap_or_default(),
+            },
+        }
+    }
+    
+    /// Get template content
+    pub fn content(&self) -> String {
+        match self {
+            Self::Requirements { title, description } => {
+                format!(
+r#"# 要件定義書 / Requirements Definition
+
+**タイトル / Title**: {}
+**作成日 / Date**: {{{{date}}}}
+**バージョン / Version**: 0.1.0
+
+## 1. 概要 / Overview
+
+{}
+
+## 2. 背景と目的 / Background and Purpose
+
+### 2.1 背景 / Background
+<!-- プロジェクトの背景、なぜこの機能が必要なのかを記述 -->
+
+### 2.2 目的 / Purpose
+<!-- この仕様で達成したい具体的な目標を記述 -->
+
+### 2.3 成功基準 / Success Criteria
+<!-- 成功と判断できる具体的な基準を記述 -->
+
+## 3. スコープ / Scope
+
+### 3.1 対象範囲 / In Scope
+<!-- この仕様に含まれる機能や要件 -->
+
+### 3.2 対象外 / Out of Scope
+<!-- この仕様に含まれない機能や要件 -->
+
+## 4. 機能要件 / Functional Requirements
+
+### 4.1 ユーザーストーリー / User Stories
+<!-- As a [role], I want [feature] so that [benefit] 形式で記述 -->
+
+### 4.2 機能一覧 / Feature List
+<!-- 実装すべき機能のリスト -->
+
+### 4.3 画面/インターフェース要件 / UI/Interface Requirements
+<!-- ユーザーインターフェースやAPIインターフェースの要件 -->
+
+## 5. 非機能要件 / Non-Functional Requirements
+
+### 5.1 パフォーマンス要件 / Performance Requirements
+<!-- 応答時間、処理速度、同時接続数などの要件 -->
+
+### 5.2 セキュリティ要件 / Security Requirements
+<!-- 認証、認可、データ保護などの要件 -->
+
+### 5.3 信頼性要件 / Reliability Requirements
+<!-- 可用性、エラー処理、データ整合性などの要件 -->
+
+### 5.4 保守性要件 / Maintainability Requirements
+<!-- コードの保守性、拡張性、ドキュメントなどの要件 -->
+
+## 6. 制約事項 / Constraints
+
+### 6.1 技術的制約 / Technical Constraints
+<!-- 使用すべき技術、プラットフォーム、言語などの制約 -->
+
+### 6.2 リソース制約 / Resource Constraints
+<!-- 時間、予算、人員などの制約 -->
+
+## 7. 前提条件 / Assumptions
+<!-- この要件定義で前提としている条件 -->
+
+## 8. リスク / Risks
+<!-- 想定されるリスクとその対策 -->
+
+## 9. 用語集 / Glossary
+<!-- プロジェクト固有の用語の定義 -->
+
+## 10. 参考資料 / References
+<!-- 参考にした資料やドキュメントのリンク -->
+"#,
+                    title, description
+                )
+            }
+            
+            Self::Design { title, requirements_summary } => {
+                format!(
+r#"# 技術設計書 / Technical Design Document
+
+**タイトル / Title**: {}
+**作成日 / Date**: {{{{date}}}}
+**バージョン / Version**: 0.1.0
+
+## 1. 概要 / Overview
+
+### 1.1 要件サマリー / Requirements Summary
+{}
+
+### 1.2 設計方針 / Design Principles
+<!-- この設計で重視する原則や方針 -->
+
+## 2. アーキテクチャ / Architecture
+
+### 2.1 全体構成図 / System Architecture
+<!-- システム全体のアーキテクチャ図 -->
+```
+[Component A] --> [Component B]
+      |               |
+      v               v
+[Component C] --> [Database]
+```
+
+### 2.2 コンポーネント設計 / Component Design
+<!-- 各コンポーネントの責務と相互作用 -->
+
+### 2.3 データフロー / Data Flow
+<!-- データの流れと処理の順序 -->
+
+## 3. 詳細設計 / Detailed Design
+
+### 3.1 モジュール構成 / Module Structure
+```
+src/
+├── module_a/
+│   ├── mod.rs
+│   └── ...
+├── module_b/
+│   ├── mod.rs
+│   └── ...
+└── ...
+```
+
+### 3.2 インターフェース定義 / Interface Definition
+<!-- API、関数、クラスなどのインターフェース -->
+
+### 3.3 データモデル / Data Model
+<!-- データ構造、スキーマ、エンティティの定義 -->
+
+## 4. 実装詳細 / Implementation Details
+
+### 4.1 主要アルゴリズム / Key Algorithms
+<!-- 重要なアルゴリズムやロジックの説明 -->
+
+### 4.2 エラー処理 / Error Handling
+<!-- エラーの種類と処理方法 -->
+
+### 4.3 ロギングとモニタリング / Logging and Monitoring
+<!-- ログ出力とモニタリングの設計 -->
+
+## 5. セキュリティ設計 / Security Design
+
+### 5.1 認証・認可 / Authentication & Authorization
+<!-- 認証と認可の仕組み -->
+
+### 5.2 データ保護 / Data Protection
+<!-- データの暗号化、アクセス制御など -->
+
+## 6. パフォーマンス設計 / Performance Design
+
+### 6.1 最適化戦略 / Optimization Strategy
+<!-- パフォーマンス向上のための設計上の工夫 -->
+
+### 6.2 キャッシング / Caching
+<!-- キャッシュの使用方法と戦略 -->
+
+## 7. 拡張性 / Extensibility
+
+### 7.1 プラグインシステム / Plugin System
+<!-- 拡張ポイントとプラグインの仕組み -->
+
+### 7.2 将来の拡張計画 / Future Extensions
+<!-- 将来的に追加可能な機能や拡張 -->
+
+## 8. テスト戦略 / Testing Strategy
+
+### 8.1 単体テスト / Unit Testing
+<!-- 単体テストの方針とカバレッジ目標 -->
+
+### 8.2 統合テスト / Integration Testing
+<!-- 統合テストの方針と重点項目 -->
+
+## 9. デプロイメント / Deployment
+
+### 9.1 デプロイ構成 / Deployment Configuration
+<!-- デプロイ環境と構成 -->
+
+### 9.2 設定管理 / Configuration Management
+<!-- 環境ごとの設定管理方法 -->
+
+## 10. 技術的決定事項 / Technical Decisions
+
+### 10.1 技術選定 / Technology Choices
+<!-- 使用する技術とその選定理由 -->
+
+### 10.2 トレードオフ / Trade-offs
+<!-- 設計上のトレードオフと判断理由 -->
+"#,
+                    title, requirements_summary
+                )
+            }
+            
+            Self::Tasks { title, design_summary } => {
+                format!(
+r#"# 実装計画書 / Implementation Plan
+
+**タイトル / Title**: {}
+**作成日 / Date**: {{{{date}}}}
+**バージョン / Version**: 0.1.0
+
+## 1. 概要 / Overview
+
+### 1.1 設計サマリー / Design Summary
+{}
+
+### 1.2 実装方針 / Implementation Strategy
+<!-- 実装の進め方と優先順位 -->
+
+## 2. マイルストーン / Milestones
+
+### Phase 1: 基盤実装 / Foundation (推定: X日)
+- [ ] 開発環境のセットアップ
+- [ ] 基本的なプロジェクト構造の作成
+- [ ] コア機能の骨組み実装
+
+### Phase 2: 機能実装 / Feature Implementation (推定: Y日)
+- [ ] 主要機能の実装
+- [ ] UI/APIの実装
+- [ ] データ永続化の実装
+
+### Phase 3: 品質向上 / Quality Enhancement (推定: Z日)
+- [ ] テストの実装
+- [ ] ドキュメントの作成
+- [ ] パフォーマンス最適化
+
+## 3. タスク詳細 / Detailed Tasks
+
+### 3.1 セットアップタスク / Setup Tasks
+| タスク | 説明 | 見積もり | 担当者 | 状態 |
+|--------|------|----------|--------|------|
+| T001 | プロジェクト初期化 | 1h | - | Todo |
+| T002 | 依存関係のインストール | 0.5h | - | Todo |
+
+### 3.2 開発タスク / Development Tasks
+| タスク | 説明 | 見積もり | 前提タスク | 状態 |
+|--------|------|----------|------------|------|
+| T101 | モジュールAの実装 | 4h | T001 | Todo |
+| T102 | モジュールBの実装 | 6h | T001 | Todo |
+| T103 | モジュール統合 | 2h | T101, T102 | Todo |
+
+### 3.3 テストタスク / Testing Tasks
+| タスク | 説明 | 見積もり | 前提タスク | 状態 |
+|--------|------|----------|------------|------|
+| T201 | 単体テスト作成 | 3h | T101, T102 | Todo |
+| T202 | 統合テスト作成 | 4h | T103 | Todo |
+
+### 3.4 ドキュメントタスク / Documentation Tasks
+| タスク | 説明 | 見積もり | 前提タスク | 状態 |
+|--------|------|----------|------------|------|
+| T301 | APIドキュメント作成 | 2h | T103 | Todo |
+| T302 | ユーザーガイド作成 | 3h | T103 | Todo |
+
+## 4. リスクと対策 / Risks and Mitigations
+
+### 4.1 技術的リスク / Technical Risks
+| リスク | 影響度 | 発生確率 | 対策 |
+|--------|--------|----------|------|
+| 外部APIの仕様変更 | 高 | 中 | APIバージョンの固定、モック作成 |
+
+### 4.2 スケジュールリスク / Schedule Risks
+| リスク | 影響度 | 発生確率 | 対策 |
+|--------|--------|----------|------|
+| 見積もりの甘さ | 中 | 高 | バッファ時間の確保 |
+
+## 5. 依存関係 / Dependencies
+
+### 5.1 外部依存 / External Dependencies
+- ライブラリA (バージョン x.y.z)
+- APIサービスB
+
+### 5.2 内部依存 / Internal Dependencies
+- 既存モジュールC
+- 共通ライブラリD
+
+## 6. 完了条件 / Definition of Done
+
+### 6.1 コード完了条件 / Code Completion Criteria
+- [ ] すべての機能が実装されている
+- [ ] コードレビューが完了している
+- [ ] リファクタリングが完了している
+
+### 6.2 品質完了条件 / Quality Completion Criteria
+- [ ] すべてのテストがパスしている
+- [ ] テストカバレッジが80%以上
+- [ ] パフォーマンス基準を満たしている
+
+### 6.3 ドキュメント完了条件 / Documentation Completion Criteria
+- [ ] APIドキュメントが完成している
+- [ ] ユーザーガイドが完成している
+- [ ] コメントが適切に記載されている
+
+## 7. 見積もりサマリー / Estimation Summary
+
+- **総見積もり時間 / Total Estimated Time**: XX時間
+- **バッファ / Buffer**: XX時間 (20%)
+- **推定完了日 / Estimated Completion Date**: YYYY-MM-DD
+
+## 8. 備考 / Notes
+<!-- その他の注意事項や申し送り事項 -->
+"#,
+                    title, design_summary
+                )
+            }
+        }
+    }
+}
+
+impl Default for TemplateEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_template_engine_variables() {
+        let mut engine = TemplateEngine::new();
+        engine.set_variable("project".to_string(), "TestProject".to_string());
+        
+        let template = SpecTemplate::Requirements {
+            title: "Test {{project}}".to_string(),
+            description: "Description for {{project}}".to_string(),
+        };
+        
+        let content = engine.generate(&template);
+        assert!(content.contains("Test TestProject"));
+        assert!(content.contains("Description for TestProject"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive spec-driven development system based on Kiro's approach
- Add three-phase workflow (requirements → design → implementation) with approval checkpoints
- Create bilingual (Japanese/English) document templates

## Changes
- Create `specs` module with core types and lifecycle management
- Add CLI commands for spec management (`vide-ticket spec`)
- Support progress tracking, version management, and ticket association
- Store specifications in `.vide-ticket/specs/` directory

## Test plan
- [x] Unit tests for specs module pass
- [x] Manual testing of all spec commands works correctly
- [x] Create, list, activate, and manage specifications successfully

🤖 Generated with [Claude Code](https://claude.ai/code)